### PR TITLE
Support for all components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ mypy = [
     "typing-extensions",
 ]
 
+
 [tool.ruff]
 exclude = [
     ".git",
@@ -84,29 +85,27 @@ exclude = [
     "examples",
     ".ipynb_checkpoints",
     "node_modules",
+    "apps",
 ]
 line-length = 165
 fix = true
 
 [tool.ruff.lint]
 ignore = [
-    "D203", # one-blank-line-before-class and `no-blank-line-before-class` (D211) are incompatible.
-    "D205", # one-line-summary-first-line
-    "D212", # multi-line-summary-first-line. Alternative is to ignore D213 `multi-line-summary-second-line
-    "D401",  # multi-line-docstring-first-line
-    "E402",  # Module level import not at top of file
-    "E712",  # Avoid equality comparisons to True
-    "E731",  # Do not assign a lambda expression, use a def
-    "N803",  # Argument name should be lowercase
-    "N806",  # Variable name should be lowercase
+    "E402", # Module level import not at top of file
+    "E712", # Avoid equality comparisons to True; use if {cond}: for truth checks
+    "E731", # Do not assign a lambda expression, use a def
+    "E741", # Ambiguous variable name
+    "W605", # Invalid escape sequence
+    "E701", # Multiple statements on one line
+    "B006", # Do not use mutable data structures for argument defaults
+    "B905", # `zip()` without an explicit `strict=` parameter
 ]
 select = [
-    "B",    # flake8-bugbear
-    "D",    # pydocstyle
-    "E",    # pycodestyle errors
-    "F",    # pyflakes
-    "W",    # pycodestyle warnings
-    "I",    # isort
+    "B",
+    "E",
+    "F",
+    "W",
     "PIE",
     "T20",
     "RUF006",
@@ -120,18 +119,25 @@ select = [
     "UP034",
     "UP036",
 ]
-
-[tool.ruff.lint.pydocstyle]
-convention = "numpy"
+unfixable = [
+    "F401", # Unused imports
+    "F841", # Unused variables
+]
 
 [tool.ruff.lint.per-file-ignores]
-# Ignore all directories named `tests`.
-"tests/**" = ["D"]
-# Ignore all files that end in `_test.py`.
-"*_test.py" = ["D"]
+"panel/tests/ui/jupyter_server_test_config.py" = ["F821"]
+"panel/compiler.py" = ["T201"]
+"panel/io/convert.py" = ["T201"]
+"panel/pane/vtk/synchronizable_*.py" = ["T201"]
+"scripts/*.py" = ["T201"]
+"hatch_build.py" = ["T201"]
 
-[tool.ruff.lint.isort]
-force-single-line = true
+[tool.isort]
+force_grid_wrap = 4
+multi_line_output = 5
+combine_as_imports = true
+lines_between_types = 1
+include_trailing_comma = true
 
 [tool.pytest.ini_options]
 addopts = "--pyargs --doctest-ignore-import-errors --color=yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "lumen >=0.9.0",
     "anndata >=0.11.4",
     "pooch >=1.8.2",
+    "scanpy >=1.11.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     "packaging",
     "panel >=1.5.0",
     "lumen >=0.9.0",
+    "anndata >=0.11.4",
+    "pooch >=1.8.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,9 @@ fix = true
 [tool.ruff.lint]
 ignore = [
     "D203", # one-blank-line-before-class and `no-blank-line-before-class` (D211) are incompatible.
+    "D205", # one-line-summary-first-line
     "D212", # multi-line-summary-first-line. Alternative is to ignore D213 `multi-line-summary-second-line
+    "D401",  # multi-line-docstring-first-line
     "E402",  # Module level import not at top of file
     "E712",  # Avoid equality comparisons to True
     "E731",  # Do not assign a lambda expression, use a def

--- a/src/lumen_anndata/app.py
+++ b/src/lumen_anndata/app.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from typing import Literal
 
 import anndata as ad
@@ -78,30 +80,27 @@ def upload_h5ad(file, table) -> int:
 #         return pn.panel(shaded * labeller(points).opts(text_color='black'))
 #     return pn.panel(shaded)
 
+async def load_data():
+    await asyncio.sleep(0.1)
+    with ui.interface.param.update(loading=True):
+        anndata_file_path = pooch.retrieve(
+            url="https://datasets.cellxgene.cziscience.com/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
+            fname="ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
+            known_hash="00ee1a7d9dbb77dc5b8e27d868d3c371f1f53e6ef79a18e5f1fede166b31e2eb",
+            path="data-download"
+        )
+        adata = pn.state.as_cached('anndata', ad.read_h5ad, filename=anndata_file_path)
+        adata = sc.datasets.pbmc68k_reduced()
+        src = AnnDataSource(adata=adata)
+        lmai.memory['sources'] = [src]
+        lmai.memory['source'] = src
 
-anndata_file_path = pooch.retrieve(
-    url="https://datasets.cellxgene.cziscience.com/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
-    fname="ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
-    known_hash="00ee1a7d9dbb77dc5b8e27d868d3c371f1f53e6ef79a18e5f1fede166b31e2eb",
-    path="data-download"
-)
-
-adata = pn.state.as_cached('anndata', ad.read_h5ad, filename='./data-download/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad')
-
-# read sample data
-adata = sc.datasets.pbmc68k_reduced()
-
-src = AnnDataSource(adata=adata)
-
-lmai.memory['sources'] = [src]
-lmai.memory['source'] = src
-
-obs = src.get('obs')
-
-lmai.ExplorerUI(
+ui = lmai.ExplorerUI(
     title='AnnData Explorer',
     # tools=[lmai.tools.FunctionTool(umap_plot, requires=['source'])],
     table_upload_callbacks={
         ".h5ad": upload_h5ad,
     },
-).servable()
+)
+pn.state.onload(load_data)
+ui.servable()

--- a/src/lumen_anndata/app.py
+++ b/src/lumen_anndata/app.py
@@ -14,24 +14,6 @@ from holoviews.operation.datashader import datashade, spread
 
 from lumen_anndata.source import AnnDataSource
 
-anndata_file_path = pooch.retrieve(
-    url="https://datasets.cellxgene.cziscience.com/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
-    fname="ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
-    known_hash="00ee1a7d9dbb77dc5b8e27d868d3c371f1f53e6ef79a18e5f1fede166b31e2eb",
-    path="data-download"
-)
-
-adata = pn.state.as_cached('anndata', ad.read_h5ad, filename='./data-download/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad')
-
-# read sample data
-adata = sc.datasets.pbmc68k_reduced()
-
-src = AnnDataSource(adata=adata)
-
-lmai.memory['sources'] = [src]
-lmai.memory['source'] = src
-
-obs = src.get('obs')
 
 class labeller(Operation):
 
@@ -78,28 +60,47 @@ def upload_h5ad(file, table) -> int:
     except Exception:
         return 0
 
+# def umap_plot(source, category):
+#     """
+#     Plots a UMAP plot of the current source data and optionally colors by category.
+#     """
+#     adata = source.get('obs', return_type="adata")
+#     data = tuple(adata.obsm["X_umap"].T)
+#     vdims = []
+#     agg = 'count'
+#     if category:
+#         data = data+(adata.obs[category].values,)
+#         vdims = [category]
+#         agg = ds.count_cat(category)
+#     points = hv.Points(data, vdims=vdims)
+#     shaded = spread(datashade(points, aggregator=agg), px=4).opts(responsive=True, height=600, xaxis=None, yaxis=None, show_legend=True, show_grid=True)
+#     if category:
+#         return pn.panel(shaded * labeller(points).opts(text_color='black'))
+#     return pn.panel(shaded)
 
-def umap_plot(source, category: Literal[tuple(obs.columns)] | None = None):
-    """
-    Plots a UMAP plot of the current source data and optionally colors by category.
-    """
-    adata = source.get('obs', return_type="adata")
-    data = tuple(adata.obsm["X_umap"].T)
-    vdims = []
-    agg = 'count'
-    if category:
-        data = data+(adata.obs[category].values,)
-        vdims = [category]
-        agg = ds.count_cat(category)
-    points = hv.Points(data, vdims=vdims)
-    shaded = spread(datashade(points, aggregator=agg), px=4).opts(responsive=True, height=600, xaxis=None, yaxis=None, show_legend=True, show_grid=True)
-    if category:
-        return pn.panel(shaded * labeller(points).opts(text_color='black'))
-    return pn.panel(shaded)
+
+anndata_file_path = pooch.retrieve(
+    url="https://datasets.cellxgene.cziscience.com/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
+    fname="ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
+    known_hash="00ee1a7d9dbb77dc5b8e27d868d3c371f1f53e6ef79a18e5f1fede166b31e2eb",
+    path="data-download"
+)
+
+adata = pn.state.as_cached('anndata', ad.read_h5ad, filename='./data-download/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad')
+
+# read sample data
+adata = sc.datasets.pbmc68k_reduced()
+
+src = AnnDataSource(adata=adata)
+
+lmai.memory['sources'] = [src]
+lmai.memory['source'] = src
+
+obs = src.get('obs')
 
 lmai.ExplorerUI(
     title='AnnData Explorer',
-    tools=[lmai.tools.FunctionTool(umap_plot, requires=['source'])],
+    # tools=[lmai.tools.FunctionTool(umap_plot, requires=['source'])],
     table_upload_callbacks={
         ".h5ad": upload_h5ad,
     },

--- a/src/lumen_anndata/app.py
+++ b/src/lumen_anndata/app.py
@@ -3,7 +3,9 @@ Lumen AI - Scanpy Explorer.
 
 This is a simple web application that allows users to explore Scanpy datasets using Lumen AI.
 """
+
 import logging
+
 from pathlib import Path
 
 import anndata as ad
@@ -11,7 +13,7 @@ import lumen.ai as lmai
 import panel as pn
 import pooch
 
-import source
+from .source import AnnDataSource
 
 pn.config.disconnect_notification = "Connection lost, try reloading the page!"
 pn.config.ready_notification = "Application fully loaded."
@@ -23,29 +25,48 @@ Help the user with their questions, and if you don't know the answer, say so.
 """
 
 db_uri = str(Path(__file__).parent / "embeddings" / "scanpy.db")
-vector_store = lmai.vector_store.DuckDBVectorStore(uri=db_uri, embeddings=lmai.embeddings.OpenAIEmbeddings())
+vector_store = lmai.vector_store.DuckDBVectorStore(
+    uri=db_uri, embeddings=lmai.embeddings.OpenAIEmbeddings()
+)
 doc_lookup = lmai.tools.VectorLookupTool(vector_store=vector_store, n=3)
+
+
+def upload_h5ad(file, table) -> int:
+    """
+    Uploads an h5ad file and returns an AnnDataSource.
+    """
+    adata = ad.read_h5ad(file)
+    try:
+        src = AnnDataSource(adata=adata)
+        lmai.memory["sources"] = lmai.memory["sources"] + [src]
+        lmai.memory["source"] = src
+        return 1
+    except Exception as e:
+        print(f"Error uploading file: {e}")
+        return 0
 
 
 fname_brca = pooch.retrieve(
     url="https://storage.googleapis.com/tcga-anndata-public/test2025-04/brca_test.h5ad",
-    known_hash="md5:0e17ecf3716174153bc31988ba6dd161"
+    known_hash="md5:0e17ecf3716174153bc31988ba6dd161",
 )
 
 brca_ad = ad.read_h5ad(fname_brca)
 logging.debug(f"AnnData Loaded: {brca_ad}")
 
-brca = source.AnnDataSource(brca_ad)
+brca = AnnDataSource(brca_ad)
 logging.debug(f"AnnDataSource: {brca}")
-
 
 ui = lmai.ExplorerUI(
     data=brca,
-    agents=[lmai.agents.ChatAgent(tools=[doc_lookup], template_overrides={"main": {"instructions": INSTRUCTIONS}})],
+    agents=[
+        lmai.agents.ChatAgent(
+            tools=[doc_lookup],
+            template_overrides={"main": {"instructions": INSTRUCTIONS}},
+        )
+    ],
     llm=lmai.llm.OpenAI(),
-    default_agents=[], log_level="debug",
-    # data=[
-    #     "/Users/cvaske/Downloads/brca_test.h5ad"
-    # ]
+    default_agents=[],
+    log_level="debug",
 )
 ui.servable()

--- a/src/lumen_anndata/app.py
+++ b/src/lumen_anndata/app.py
@@ -13,7 +13,7 @@ import lumen.ai as lmai
 import panel as pn
 import pooch
 
-from .source import AnnDataSource
+from lumen_anndata.source import AnnDataSource
 
 pn.config.disconnect_notification = "Connection lost, try reloading the page!"
 pn.config.ready_notification = "Application fully loaded."
@@ -54,7 +54,7 @@ fname_brca = pooch.retrieve(
 brca_ad = ad.read_h5ad(fname_brca)
 logging.debug(f"AnnData Loaded: {brca_ad}")
 
-brca = AnnDataSource(brca_ad)
+brca = AnnDataSource(adata=brca_ad)
 logging.debug(f"AnnDataSource: {brca}")
 
 ui = lmai.ExplorerUI(
@@ -68,5 +68,6 @@ ui = lmai.ExplorerUI(
     llm=lmai.llm.OpenAI(),
     default_agents=[],
     log_level="debug",
+    table_upload_callbacks={"h5ad": upload_h5ad},
 )
 ui.servable()

--- a/src/lumen_anndata/app.py
+++ b/src/lumen_anndata/app.py
@@ -1,24 +1,14 @@
-import asyncio
-
-from typing import Literal
-
 import anndata as ad
-import datashader as ds
 import holoviews as hv
 import lumen.ai as lmai
-import panel as pn
 import param
-import pooch
-import scanpy as sc
 
 from holoviews.operation import Operation
-from holoviews.operation.datashader import datashade, spread
 
 from lumen_anndata.source import AnnDataSource
 
 
 class labeller(Operation):
-
     column = param.String()
 
     max_labels = param.Integer(10)
@@ -27,13 +17,21 @@ class labeller(Operation):
 
     streams = param.List([hv.streams.RangeXY])
 
-    x_range = param.Tuple(default=None, length=2, doc="""
+    x_range = param.Tuple(
+        default=None,
+        length=2,
+        doc="""
        The x_range as a tuple of min and max x-value. Auto-ranges
-       if set to None.""")
+       if set to None.""",
+    )
 
-    y_range = param.Tuple(default=None, length=2, doc="""
+    y_range = param.Tuple(
+        default=None,
+        length=2,
+        doc="""
        The x_range as a tuple of min and max x-value. Auto-ranges
-       if set to None.""")
+       if set to None.""",
+    )
 
     def _process(self, el, key=None):
         if self.p.x_range and self.p.y_range:
@@ -41,12 +39,19 @@ class labeller(Operation):
         df = el.dframe()
         xd, yd, cd = el.dimensions()[:3]
         col = self.p.column or cd.name
-        result = df.groupby(col).agg(
-            count=(col, 'size'),  # count of rows per group
-            x=(xd.name, 'mean'),
-            y=(yd.name, 'mean')
-        ).query(f'count > {self.p.min_count}').sort_values('count', ascending=False).iloc[:self.p.max_labels].reset_index()
-        return hv.Labels(result, ['x', 'y'], col)
+        result = (
+            df.groupby(col)
+            .agg(
+                count=(col, "size"),  # count of rows per group
+                x=(xd.name, "mean"),
+                y=(yd.name, "mean"),
+            )
+            .query(f"count > {self.p.min_count}")
+            .sort_values("count", ascending=False)
+            .iloc[: self.p.max_labels]
+            .reset_index()
+        )
+        return hv.Labels(result, ["x", "y"], col)
 
 
 def upload_h5ad(file, table) -> int:
@@ -56,51 +61,18 @@ def upload_h5ad(file, table) -> int:
     adata = ad.read_h5ad(file)
     try:
         src = AnnDataSource(adata=adata)
-        lmai.memory['sources'] = lmai.memory["sources"] + [src]
-        lmai.memory['source'] = src
+        lmai.memory["sources"] = lmai.memory["sources"] + [src]
+        lmai.memory["source"] = src
         return 1
     except Exception:
         return 0
 
-# def umap_plot(source, category):
-#     """
-#     Plots a UMAP plot of the current source data and optionally colors by category.
-#     """
-#     adata = source.get('obs', return_type="adata")
-#     data = tuple(adata.obsm["X_umap"].T)
-#     vdims = []
-#     agg = 'count'
-#     if category:
-#         data = data+(adata.obs[category].values,)
-#         vdims = [category]
-#         agg = ds.count_cat(category)
-#     points = hv.Points(data, vdims=vdims)
-#     shaded = spread(datashade(points, aggregator=agg), px=4).opts(responsive=True, height=600, xaxis=None, yaxis=None, show_legend=True, show_grid=True)
-#     if category:
-#         return pn.panel(shaded * labeller(points).opts(text_color='black'))
-#     return pn.panel(shaded)
-
-async def load_data():
-    await asyncio.sleep(0.1)
-    with ui.interface.param.update(loading=True):
-        anndata_file_path = pooch.retrieve(
-            url="https://datasets.cellxgene.cziscience.com/ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
-            fname="ad4aac9c-28e6-4a1f-ab48-c4ae7154c0cb.h5ad",
-            known_hash="00ee1a7d9dbb77dc5b8e27d868d3c371f1f53e6ef79a18e5f1fede166b31e2eb",
-            path="data-download"
-        )
-        adata = pn.state.as_cached('anndata', ad.read_h5ad, filename=anndata_file_path)
-        src = AnnDataSource(adata=adata)
-        lmai.memory['sources'] = [src]
-        lmai.memory['source'] = src
 
 ui = lmai.ExplorerUI(
-    title='AnnData Explorer',
-    # tools=[lmai.tools.FunctionTool(umap_plot, requires=['source'])],
+    title="AnnData Explorer",
     table_upload_callbacks={
         ".h5ad": upload_h5ad,
     },
-    log_level="DEBUG"
+    log_level="DEBUG",
 )
-pn.state.onload(load_data)
 ui.servable()

--- a/src/lumen_anndata/app.py
+++ b/src/lumen_anndata/app.py
@@ -90,7 +90,6 @@ async def load_data():
             path="data-download"
         )
         adata = pn.state.as_cached('anndata', ad.read_h5ad, filename=anndata_file_path)
-        adata = sc.datasets.pbmc68k_reduced()
         src = AnnDataSource(adata=adata)
         lmai.memory['sources'] = [src]
         lmai.memory['source'] = src
@@ -101,6 +100,7 @@ ui = lmai.ExplorerUI(
     table_upload_callbacks={
         ".h5ad": upload_h5ad,
     },
+    log_level="DEBUG"
 )
 pn.state.onload(load_data)
 ui.servable()

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -316,9 +316,11 @@ class AnnDataSource(DuckDBSource):
         if df is not None:
             try:
                 self.connection.register(table_name, df)
-                self._materialized_tables.append(table_name)
             except Exception as e:
-                raise RuntimeError(f"Failed to register table '{table_name}' with DuckDB: {e}") from e
+                # Create empty table
+                self.connection.execute(f"CREATE TABLE {table_name} AS SELECT * FROM (SELECT 1 AS dummy) WHERE 0")
+                self.param.warning(f"Failed to register table '{table_name}' with DuckDB: {e}")
+            self._materialized_tables.append(table_name)
         else:
             # Do not raise error here, as some 'uns' items might not be convertible.
             # Let subsequent SQL query fail if the table is truly needed and couldn't be made.

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -492,11 +492,11 @@ class AnnDataSource(DuckDBSource):
             if not self._is_table_excluded(t[0])
         }
         if materialized_only:
-            all_tables |= set(self._materialized_tables)
-        else:
             # TODO: figure out why SHOW TABLES on create_source_sql_expr results in all tables
             # even if not materialized...
             all_tables -= set(self._component_registry.keys()) - set(self._materialized_tables)
+        else:
+            all_tables |= set(self._component_registry)
         return sorted(all_tables)
 
     def execute(self, sql_query: str, *args: Any, **kwargs: Any) -> pd.DataFrame:

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -472,15 +472,12 @@ class AnnDataSource(DuckDBSource):
 
     def get_tables(self, materialized_only: bool = False) -> list[str]:
         """Get list of available tables."""
+        all_tables = set(super().get_tables())
         if materialized_only:
-            return self._materialized_tables[:]
-
-        potential_tables = set(self._component_registry.keys())
-        if self._adata_store:
-            potential_tables.add("obs")
-            potential_tables.add("var")
-
-        return sorted(list(potential_tables))
+            all_tables |= set(self._materialized_tables)
+        else:
+            all_tables |= set(self._component_registry.keys())
+        return sorted(all_tables)
 
     def execute(self, sql_query: str, *args: Any, **kwargs: Any) -> pd.DataFrame:
         """Execute SQL query, automatically materializing referenced AnnData tables if needed."""

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -249,7 +249,7 @@ class AnnDataSource(DuckDBSource):
                 return pd.DataFrame({r_name: r_idx[coo.row], c_name: c_idx[coo.col], "value": coo.data})
             else:  # Dense matrix
                 matrix_np = cast(np.ndarray, matrix)
-                row_indices, col_indices = np.meshgrid(np.arange(matrix_np.shape[0]), np.arange(matrix_np.shape[1]), indexing="ij")
+                row_indices, col_indices = np.indices(matrix_np.shape)
                 return pd.DataFrame(
                     {
                         r_name: r_idx[row_indices.ravel()],
@@ -529,5 +529,5 @@ class AnnDataSource(DuckDBSource):
         return self
 
     def to_spec(self, context: dict[str, Any] | None = None) -> dict[str, Any]:
-        # TODO: temporarily disable this
+        # TODO: temporarily disable this until Lumen internal supports unserializable objects
         return {}

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -1,136 +1,494 @@
+"""Support AnnData datasets as a Lumen DuckDB source."""
+
 from __future__ import annotations
 
-import os
 import pathlib
-from typing import Any
+from typing import Any, Literal, Union, cast
 
 import anndata as ad
+import numpy as np
+import pandas as pd
 import param
+import scipy.sparse as sp
 from anndata import AnnData
 from lumen.sources.duckdb import DuckDBSource, cached
-from lumen.transforms import SQLFilter, SQLColumns, SQLLimit
+from lumen.transforms import SQLFilter
+from sqlglot import parse_one
+from sqlglot.expressions import Table
+
+ComponentInfo = dict[str, Union[Any, str, bool, None, pd.DataFrame, np.ndarray, sp.spmatrix]]
+ComponentRegistry = dict[str, ComponentInfo]
 
 
 class AnnDataSource(DuckDBSource):
+    """AnnDataSource provides a Lumen DuckDB wrapper for AnnData datasets.
+
+    Core principles:
+    - `obs` and `var` tables are materialized immediately for metadata querying and filtering.
+    - All other AnnData components are registered but lazily materialized into SQL
+      tables only when directly queried for a pandas DataFrame.
+    - ID-based filtering (`_obs_ids_selected`, `_var_ids_selected`) tracks selections.
+    - Selections are updated *only* by direct queries on `obs` or `var` tables.
+    - `return_type='anndata'` efficiently returns filtered AnnData objects (copies)
+      by applying current selections and query filters directly to the AnnData object,
+      avoiding unnecessary SQL materialization of large data matrices.
+    - Use `reset_selection()` to clear current selection state.
     """
-    AnnDataSource provides a Lumen DuckDB wrapper for AnnData datasets.
 
-    It works by mirroring the `obs` and `var` tables into DuckDB and
-    tracking selections along the obs and var dimensions.
+    adata = param.ClassSelector(
+        class_=(AnnData, str, pathlib.Path),
+        doc="An AnnData instance or path to a .h5ad file to load.",
+    )
 
-    The `.get` method extends the default behavior of a DuckDB source
-    by making it possible to return the AnnData object instead of the
-    requested table. By setting `return_type="anndata"` you can request
-    the AnnData object with the current selections applied.
-    """
+    dense_matrix_warning_threshold = param.Integer(
+        default=1_000_000,
+        doc="""Threshold (number of elements) above which to warn when materializing
+             dense matrices to SQL. Set to 0 to disable warnings.""",
+    )
 
-    adata = param.ClassSelector(class_=(AnnData, str, pathlib.Path), doc="""
-        An AnnData instance or path to a .h5ad file to load.""")
+    ephemeral = param.Boolean(default=True, doc="Always ephemeral (in-memory) by virtue of AnnDataSource.")
 
-    ephemeral = param.Boolean(default=True, doc="""
-        Always ephemeral (in-memory) by virtue of AnnSQL.""")
-
-    filter_in_sql = param.Boolean(default=True, doc="""
-        Whether to apply filters in SQL or in-memory.""")
+    filter_in_sql = param.Boolean(default=True, doc="Whether to apply filters in SQL or in-memory.")
 
     source_type = "anndata"
 
-    def __init__(self, **params: Any):
-        adata = params.get("adata")
-        _tables = params.pop("_tables", None)
-        if '_adata' in params:
-            self._adata = params.pop('_adata')
-        else:
-            if isinstance(adata, (pathlib.Path, str)):
-                self._adata = ad.read_h5ad(adata)
+    _adata_store: AnnData | None = None
+    _component_registry: ComponentRegistry = {}
+    _materialized_tables: list[str] = []
+
+    _obs_ids_selected: np.ndarray | list[str] | None = None
+    _var_ids_selected: np.ndarray | list[str] | None = None
+
+    def __init__(self, adata: AnnData, **params: Any):
+        """Initialize AnnDataSource from an AnnData object or file path."""
+        # Initialize internal state from params if provided (for Lumen's state management)
+        self._component_registry = params.pop("_component_registry", {})
+        self._materialized_tables = params.pop("_materialized_tables", [])
+        self._obs_ids_selected = params.pop("_obs_ids_selected", None)
+        self._var_ids_selected = params.pop("_var_ids_selected", None)
+        self._adata_store = params.pop("_adata_store", None)
+
+        if self._adata_store is None:
+            if isinstance(adata, (str, pathlib.Path)):
+                self._adata_store = ad.read_h5ad(adata)
             elif isinstance(adata, AnnData):
-                self._adata = adata
+                self._adata_store = adata.copy()
             else:
-                raise ValueError("`adata` must be an AnnData or path to an .h5ad file.")
-            obs = self._adata.obs.copy()
-            obs['obs_id'] = obs.index.values
-            var = self._adata.var.copy()
-            var['var_id'] = var.index.values
-            params['mirrors'] = {
-                'obs': obs,
-                'var': var
-            }
+                raise ValueError("Invalid 'adata' parameter: must be AnnData instance or path to .h5ad file.")
+
+        initial_mirrors = {}
+        if self._adata_store:
+            if not self._component_registry:  # Build registry if not loaded from state
+                self._component_registry = self._build_component_registry_map()
+
+            # Prepare obs table
+            obs_df = self._adata_store.obs.copy()
+            obs_df["obs_id"] = obs_df.index.astype(str).values
+            initial_mirrors["obs"] = obs_df
+
+            # Prepare var table
+            var_df = self._adata_store.var.copy()
+            var_df["var_id"] = var_df.index.astype(str).values
+            initial_mirrors["var"] = var_df
+
+        params["mirrors"] = initial_mirrors
         super().__init__(**params)
-        if _tables is not None:
-            self._tables = _tables
+
+        if self._adata_store and self.connection and initial_mirrors:
+            for table_name, df in initial_mirrors.items():
+                self.connection.register(table_name, df)
+                if table_name not in self._materialized_tables:
+                    self._materialized_tables.append(table_name)
+
+    @staticmethod
+    def _get_adata_slice_labels(
+        original_adata_index: pd.Index,
+        selected_ids: pd.Series | np.ndarray | list[str] | None,
+    ) -> Union[slice, list[str]]:
+        """Convert selection IDs to a format suitable for AnnData slicing (sorted list of present string IDs)."""
+        if selected_ids is None:
+            return slice(None)
+
+        if not isinstance(original_adata_index, pd.Index):
+            original_adata_index = pd.Index(original_adata_index)
+
+        original_str_index = original_adata_index.astype(str)
+
+        if isinstance(selected_ids, (pd.Series, np.ndarray)):
+            unique_selected_ids = pd.Index(selected_ids).unique().astype(str)
+        elif isinstance(selected_ids, list):
+            unique_selected_ids = pd.Index(list(set(selected_ids))).astype(str)
+
+        present_ids = original_str_index.intersection(unique_selected_ids)
+        return sorted(present_ids.to_list())
+
+    def _build_component_registry_map(self) -> ComponentRegistry:
+        """Create registry of all AnnData components that can be mirrored to SQL tables."""
+        if not self._adata_store:
+            return {}
+
+        registry: ComponentRegistry = {}
+        adata = self._adata_store
+
+        registry["obs"] = {"obj_ref": adata.obs, "type": "obs", "adata_key": None}
+        registry["var"] = {"obj_ref": adata.var, "type": "var", "adata_key": None}
+
+        if adata.X is not None:
+            registry["X"] = {
+                "obj_ref": adata.X,
+                "type": "matrix",
+                "adata_key": None,
+                "is_sparse": sp.issparse(adata.X),
+                "row_dim": "obs",
+                "col_dim": "var",
+            }
+
+        for key, layer in adata.layers.items():
+            registry[f"layer_{key}"] = {
+                "obj_ref": layer,
+                "type": "matrix",
+                "adata_key": key,
+                "is_sparse": sp.issparse(layer),
+                "row_dim": "obs",
+                "col_dim": "var",
+            }
+        for key, mat in adata.obsp.items():
+            registry[f"obsp_{key}"] = {
+                "obj_ref": mat,
+                "type": "matrix",
+                "adata_key": key,
+                "is_sparse": sp.issparse(mat),
+                "row_dim": "obs",
+                "col_dim": "obs",
+            }
+        for key, mat in adata.varp.items():
+            registry[f"varp_{key}"] = {
+                "obj_ref": mat,
+                "type": "matrix",
+                "adata_key": key,
+                "is_sparse": sp.issparse(mat),
+                "row_dim": "var",
+                "col_dim": "var",
+            }
+        for key, arr in adata.obsm.items():
+            registry[f"obsm_{key}"] = {
+                "obj_ref": arr,
+                "type": "multidim",
+                "adata_key": key,
+                "dim": "obs",
+            }
+        for key, arr in adata.varm.items():
+            registry[f"varm_{key}"] = {
+                "obj_ref": arr,
+                "type": "multidim",
+                "adata_key": key,
+                "dim": "var",
+            }
+        if adata.uns:  # Only add uns_keys if uns is not empty
+            registry["uns_keys"] = {"obj_ref": list(adata.uns.keys()), "type": "uns_keys", "adata_key": None}
+            for key, item in adata.uns.items():
+                if isinstance(item, (pd.DataFrame, np.ndarray, dict, list, tuple, str, int, float, bool)):  # Common serializable types
+                    registry[f"uns_{key}"] = {"obj_ref": item, "type": "uns", "adata_key": key}
+        return registry
+
+    def _convert_component_to_sql_df(self, table_name: str) -> pd.DataFrame | None:
+        """Convert an AnnData component to a DataFrame suitable for SQL querying."""
+        if not self._adata_store:
+            return None
+        if table_name not in self._component_registry:
+            raise ValueError(f"Component '{table_name}' not found in AnnData registry.")
+
+        comp_info = self._component_registry[table_name]
+        obj_data = comp_info["obj_ref"]
+        obj_type = cast(str, comp_info["type"])
+
+        if obj_type == "obs":
+            df = cast(pd.DataFrame, obj_data).copy()
+            df["obs_id"] = df.index.astype(str).values
+            return df
+        if obj_type == "var":
+            df = cast(pd.DataFrame, obj_data).copy()
+            df["var_id"] = df.index.astype(str).values
+            return df
+
+        if obj_type == "matrix":
+            matrix = obj_data
+            row_dim_type = cast(str, comp_info["row_dim"])  # 'obs' or 'var'
+            col_dim_type = cast(str, comp_info["col_dim"])  # 'obs' or 'var'
+
+            r_idx = (self._adata_store.obs_names if row_dim_type == "obs" else self._adata_store.var_names).astype(str)
+            c_idx = (self._adata_store.var_names if col_dim_type == "var" else self._adata_store.obs_names).astype(str)
+
+            r_name = (
+                "obs_id"
+                if row_dim_type == "obs" and col_dim_type == "var"
+                else (
+                    "var_id"
+                    if row_dim_type == "var" and col_dim_type == "obs"
+                    else (f"{row_dim_type}_id_1" if row_dim_type == col_dim_type else f"{row_dim_type}_id")
+                )
+            )
+            c_name = (
+                "var_id"
+                if col_dim_type == "var" and row_dim_type == "obs"
+                else (
+                    "obs_id"
+                    if col_dim_type == "obs" and row_dim_type == "var"
+                    else (f"{col_dim_type}_id_2" if row_dim_type == col_dim_type else f"{col_dim_type}_id")
+                )
+            )
+
+            if sp.issparse(matrix):
+                coo = matrix.tocoo()
+                return pd.DataFrame({r_name: r_idx[coo.row], c_name: c_idx[coo.col], "value": coo.data})
+            else:  # Dense matrix
+                matrix_np = cast(np.ndarray, matrix)
+                row_indices, col_indices = np.meshgrid(np.arange(matrix_np.shape[0]), np.arange(matrix_np.shape[1]), indexing="ij")
+                return pd.DataFrame(
+                    {
+                        r_name: r_idx[row_indices.ravel()],
+                        c_name: c_idx[col_indices.ravel()],
+                        "value": matrix_np.ravel(),
+                    }
+                )
+
+        if obj_type == "multidim":
+            array_like = obj_data
+            adata_key = cast(str, comp_info["adata_key"])
+            dim_type = cast(str, comp_info["dim"])  # 'obs' or 'var'
+            id_col_name = f"{dim_type}_id"
+            id_labels = (self._adata_store.obs_names if dim_type == "obs" else self._adata_store.var_names).astype(str)
+
+            if isinstance(array_like, pd.DataFrame):
+                df = array_like.copy()
+            elif isinstance(array_like, np.ndarray):
+                if array_like.ndim == 1:
+                    df = pd.DataFrame({f"{adata_key}_0": array_like})
+                elif array_like.ndim == 2:
+                    df = pd.DataFrame(array_like, columns=[f"{adata_key}_{i}" for i in range(array_like.shape[1])])
+                else:
+                    return None  # Cannot easily represent >2D array as single SQL table
+            else:
+                return None
+
+            df[id_col_name] = id_labels[: len(df)]
+            return df.reset_index(drop=True)
+
+        if obj_type == "uns_keys":
+            return pd.DataFrame({"uns_key": cast(list[str], obj_data)})
+        if obj_type == "uns":
+            item = obj_data
+            if isinstance(item, pd.DataFrame):
+                return item.reset_index()
+            if isinstance(item, np.ndarray):
+                if item.ndim == 1:
+                    return pd.DataFrame({"value": item})
+                if item.ndim == 2:
+                    return pd.DataFrame(item, columns=[f"col_{i}" for i in range(item.shape[1])])
+            if isinstance(item, dict):
+                return pd.DataFrame([item])
+            if isinstance(item, (list, tuple)) and all(isinstance(i, (str, int, float, bool)) for i in item):
+                return pd.DataFrame({"value": item})
+            if isinstance(item, (str, int, float, bool)):
+                return pd.DataFrame({"value": [item]})
+
+        return None
+
+    def _ensure_table_materialized(self, table_name: str):
+        """Materialize an AnnData component into a DuckDB table if not already done."""
+        if table_name in self._materialized_tables:
+            return
+        if table_name not in self._component_registry:
+            if table_name not in self.get_tables():
+                raise ValueError(f"Table '{table_name}' is not a known AnnData component or predefined table.")
+            return
+
+        comp_info = self._component_registry[table_name]
+        if comp_info.get("type") == "matrix":
+            matrix = comp_info["obj_ref"]
+            size = matrix.shape[0] * matrix.shape[1]
+            is_sparse = comp_info.get("is_sparse", False)
+            if not is_sparse and self.dense_matrix_warning_threshold > 0 and size > self.dense_matrix_warning_threshold:
+                self.param.warning(
+                    f"Materializing dense matrix '{table_name}' ({matrix.shape[0]}x{matrix.shape[1]} = {size:,} elements) to SQL. "
+                    f"This is MEMORY INTENSIVE. Consider using ID-based filtering with `return_type='anndata'`."
+                )
+
+        df = self._convert_component_to_sql_df(table_name)
+        if df is not None:
+            try:
+                self.connection.register(table_name, df)
+                self._materialized_tables.append(table_name)
+            except Exception as e:
+                raise RuntimeError(f"Failed to register table '{table_name}' with DuckDB: {e}") from e
         else:
-            self._tables = None
-            with self.param.update(tables=None):
-                self._tables = self.get_tables()
-        self._obs_ids = params.get('_obs_ids', None)
-        self._var_ids = params.get('_var_ids', None)
+            # Do not raise error here, as some 'uns' items might not be convertible.
+            # Let subsequent SQL query fail if the table is truly needed and couldn't be made.
+            self.param.warning(f"Component '{table_name}' conversion to DataFrame failed; cannot materialize for SQL.")
 
-    def create_sql_expr_source(
-        self, tables: dict[str, str], materialize: bool = True, **kwargs
-    ):
-        params = dict(self.param.values(), **kwargs)
-        params.pop('tables')
-        params['_adata'] = self._adata
-        params['_tables'] = self._tables
-        source = super().create_sql_expr_source(tables.copy(), materialize, **params)
-        source.tables.update({table: self.get_sql_expr(table) for table in self._tables})
-        obs_ids = self._obs_ids
-        var_ids = self._var_ids
-        for table in tables:
-            df = source.get(table)
-            if "obs_id" in df.columns:
-                if obs_ids is None:
-                    obs_ids = df["obs_id"]
-                else:
-                    obs_ids = obs_ids[obs_ids.isin(df["obs_id"])]
-            if "var_id" in df.columns:
-                if var_ids is None:
-                    var_ids = df["var_id"]
-                else:
-                    var_ids = var_ids[var_ids.isin(df["var_id"])]
-        source._obs_ids = obs_ids
-        source._var_ids = var_ids
-        return source
+    def _has_column_in_sql_table(self, table_name: str, column_name: str) -> bool:
+        """Check if a materialized SQL table has a specific column."""
+        if table_name == "obs" and column_name == "obs_id":
+            return True
+        if table_name == "var" and column_name == "var_id":
+            return True
 
-    def get_tables(self):
-        if self.tables is None and self._tables:
-            return self._tables.copy()
-        return super().get_tables()
-
-    def _has(self, sql_expr, column='obs_id'):
-        try:
-            test_expr = sql_expr
-            for t in (SQLColumns(columns=["obs_id"]), SQLLimit(limit=1)):
-                test_expr = t.apply(test_expr)
-            self.execute(test_expr)
-        except Exception:
+        if table_name not in self._materialized_tables:
+            # If table is not materialized, we can't check its columns via SQL describe.
+            # Try to infer from component registry for unmaterialized components.
+            if table_name in self._component_registry:
+                comp_info = self._component_registry[table_name]
+                comp_type = comp_info.get("type")
+                if comp_type == "obs" and column_name in self._adata_store.obs.columns:
+                    return True
+                if comp_type == "var" and column_name in self._adata_store.var.columns:
+                    return True
             return False
-        else:
-             return True
+
+        schema_df = self.execute(f'PRAGMA table_info("{table_name}")')
+        return column_name in schema_df["name"].astype(str).values
+
+    def _prepare_anndata_slice_from_query(
+        self,
+        initial_obs_slice_labels: Union[slice, list[str]],
+        initial_var_slice_labels: Union[slice, list[str]],
+        query_filters: dict[str, Any],
+    ) -> tuple[list[str], list[str]]:
+        """
+        Refine AnnData observation and variable slices based on query_filters.
+        Applies filters to adata.obs and adata.var.
+        """
+        effective_obs_names = self._adata_store.obs_names if isinstance(initial_obs_slice_labels, slice) else pd.Index(initial_obs_slice_labels)
+        effective_var_names = self._adata_store.var_names if isinstance(initial_var_slice_labels, slice) else pd.Index(initial_var_slice_labels)
+
+        final_obs_keep_mask = pd.Series(True, index=effective_obs_names)
+        final_var_keep_mask = pd.Series(True, index=effective_var_names)
+
+        if not effective_obs_names.empty:
+            for key, value in query_filters.items():
+                if key in self._adata_store.obs.columns:
+                    obs_column_data = self._adata_store.obs.loc[effective_obs_names, key]
+                    condition = obs_column_data.isin(value) if isinstance(value, (list, tuple)) else (obs_column_data == value)
+                    final_obs_keep_mask &= condition.reindex(effective_obs_names, fill_value=False)
+
+        if not effective_var_names.empty:
+            for key, value in query_filters.items():
+                if key in self._adata_store.var.columns:
+                    var_column_data = self._adata_store.var.loc[effective_var_names, key]
+                    condition = var_column_data.isin(value) if isinstance(value, (list, tuple)) else (var_column_data == value)
+                    final_var_keep_mask &= condition.reindex(effective_var_names, fill_value=False)
+
+        final_obs_labels = effective_obs_names[final_obs_keep_mask].tolist()
+        final_var_labels = effective_var_names[final_var_keep_mask].tolist()
+
+        return final_obs_labels, final_var_labels
+
+    def _get_as_anndata(self, query: dict[str, Any]) -> AnnData:
+        """Return a filtered AnnData object based on current selections and query."""
+        obs_slice_labels = self._get_adata_slice_labels(self._adata_store.obs_names, self._obs_ids_selected)
+        var_slice_labels = self._get_adata_slice_labels(self._adata_store.var_names, self._var_ids_selected)
+
+        final_obs_labels, final_var_labels = self._prepare_anndata_slice_from_query(obs_slice_labels, var_slice_labels, query)
+        return self._adata_store[final_obs_labels, final_var_labels].copy()
+
+    def _get_as_dataframe(self, table: str, query: dict[str, Any], sql_transforms: list) -> pd.DataFrame:
+        """Get table data as DataFrame, materializing if necessary."""
+        is_materialized = table in self._materialized_tables
+        is_registered = table in self._component_registry
+
+        if is_registered and not is_materialized:
+            self._ensure_table_materialized(table)
+
+        if table not in self._materialized_tables and table not in self.get_tables():
+            raise ValueError(f"Table '{table}' could not be prepared for SQL query.")
+
+        conditions = self._build_sql_conditions(table, query)
+
+        current_sql_expr = self.get_sql_expr(table)
+        applied_transforms = sql_transforms
+        if self.filter_in_sql and conditions:
+            applied_transforms = [SQLFilter(conditions=conditions)] + sql_transforms
+
+        final_sql_expr = current_sql_expr
+        for transform in applied_transforms:
+            final_sql_expr = transform.apply(final_sql_expr)
+
+        return self.execute(final_sql_expr)
+
+    def _build_sql_conditions(self, table: str, query: dict) -> list:
+        """Build conditions for SQL filtering from selections and query."""
+        conditions = []
+
+        if self._obs_ids_selected is not None and self._has_column_in_sql_table(table, "obs_id"):
+            obs_ids = list(pd.Series(self._obs_ids_selected).unique().astype(str))
+            if obs_ids:
+                conditions.append(("obs_id", obs_ids))
+
+        if self._var_ids_selected is not None and self._has_column_in_sql_table(table, "var_id"):
+            var_ids = list(pd.Series(self._var_ids_selected).unique().astype(str))
+            if var_ids:
+                conditions.append(("var_id", var_ids))
+
+        for key, value in query.items():
+            if self._has_column_in_sql_table(table, key) or table not in self._component_registry:
+                conditions.append((key, value))
+
+        return conditions
 
     @cached
-    def get(self, table, **query):
-        query.pop('__dask', None)
-        return_type = query.pop('return_type', 'pandas')
-        sql_expr = self.get_sql_expr(table)
-        sql_transforms = query.pop('sql_transforms', [])
-        conditions = list(query.items())
-        if self._obs_ids is not None and self._has(sql_expr, 'obs_id'):
-            # ALERT: This is potentially terrible since obs_ids can be huge
-            #        But since the SQL table
-            conditions.append(("obs_id", list(self._obs_ids)))
-        if self._var_ids is not None and self._has(sql_expr, 'var_id'):
-            # ALERT: This is potentially terrible since obs_ids can be huge
-            #        But since the SQL table
-            conditions.append(("var_id", list(self._var_ids)))
-        if self.filter_in_sql:
-            sql_transforms = [SQLFilter(conditions=conditions)] + sql_transforms
-        for st in sql_transforms:
-            sql_expr = st.apply(sql_expr)
-        df = self.execute(sql_expr)
-        if return_type == 'adata':
-            adata = self._adata
-            obs_slice = df["obs_id"] if "obs_id" in df.columns else slice(None)
-            var_slice = df["var_id"] if "var_id" in df.columns else slice(None)
-            return adata[obs_slice, var_slice]
-        return df
+    def get(self, table: str, **query: Any) -> Union[pd.DataFrame, AnnData]:
+        """Get data from AnnData as DataFrame or filtered AnnData object."""
+        query.pop("__dask", None)  # Remove dask-specific parameter
+        return_type = cast(Literal["pandas", "anndata"], query.pop("return_type", "pandas"))
+        sql_transforms = query.pop("sql_transforms", [])
+
+        if return_type == "anndata":
+            return self._get_as_anndata(query)
+
+        df_result = self._get_as_dataframe(table, query, sql_transforms)
+        if table == "obs" and "obs_id" in df_result.columns:
+            self._obs_ids_selected = df_result["obs_id"].unique()
+        elif table == "var" and "var_id" in df_result.columns:
+            self._var_ids_selected = df_result["var_id"].unique()
+        return df_result
+
+    def get_tables(self, materialized_only: bool = False) -> list[str]:
+        """Get list of available tables."""
+        if materialized_only:
+            return self._materialized_tables[:]
+
+        potential_tables = set(self._component_registry.keys())
+        if self._adata_store:
+            potential_tables.add("obs")
+            potential_tables.add("var")
+
+        return sorted(list(potential_tables))
+
+    def execute(self, sql_query: str, *args: Any, **kwargs: Any) -> pd.DataFrame:
+        """Execute SQL query, automatically materializing referenced AnnData tables if needed."""
+        parsed_query = parse_one(sql_query)
+        if parsed_query:  # Ensure parsing was successful
+            tables_in_query = {table.name for table in parsed_query.find_all(Table)}
+            for table_name in tables_in_query:
+                if table_name in self._component_registry and table_name not in self._materialized_tables:
+                    self._ensure_table_materialized(table_name)
+        return super().execute(sql_query, *args, **kwargs)
+
+    def reset_selection(self, dim: str | None = None) -> "AnnDataSource":
+        """Reset selection tracking for specified dimension(s).
+
+        Parameters
+        ----------
+        dim : str or None
+            Dimension to reset: 'obs', 'var', or None (resets both).
+
+        Returns
+        -------
+        AnnDataSource
+            The instance itself, for method chaining.
+        """
+        if dim is None or dim.lower() == "obs":
+            self._obs_ids_selected = None
+        if dim is None or dim.lower() == "var":
+            self._var_ids_selected = None
+        return self

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Any, Literal, Union, cast
+
+from typing import (
+    Any, Literal, Union, cast,
+)
 
 import anndata as ad
 import numpy as np
 import pandas as pd
 import param
 import scipy.sparse as sp
+
 from anndata import AnnData
-from lumen.sources.duckdb import DuckDBSource, cached
+from lumen.sources.duckdb import DuckDBSource
 from lumen.transforms import SQLFilter
 from sqlglot import parse_one
 from sqlglot.expressions import Table
@@ -435,9 +439,22 @@ class AnnDataSource(DuckDBSource):
 
         return conditions
 
-    @cached
+    # @cached  # TODO: figure out what to do with this alongside reset_selection
     def get(self, table: str, **query: Any) -> Union[pd.DataFrame, AnnData]:
-        """Get data from AnnData as DataFrame or filtered AnnData object."""
+        """Get data from AnnData as DataFrame or filtered AnnData object.
+
+        Parameters
+        ----------
+        table : str
+            Name of the table to query (e.g., 'obs', 'var', 'X', etc.).
+        query : dict
+            Additional query parameters to filter the data, e.g. {'obs_id': ['cell1', 'cell2']}.
+
+        Returns
+        -------
+        Union[pd.DataFrame, AnnData]
+            DataFrame or AnnData object containing the queried data.
+        """
         query.pop("__dask", None)  # Remove dask-specific parameter
         return_type = cast(Literal["pandas", "anndata"], query.pop("return_type", "pandas"))
         sql_transforms = query.pop("sql_transforms", [])

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -63,8 +63,11 @@ class AnnDataSource(DuckDBSource):
     _obs_ids_selected: np.ndarray | list[str] | None = None
     _var_ids_selected: np.ndarray | list[str] | None = None
 
-    def __init__(self, adata: AnnData, **params: Any):
+    def __init__(self, **params: Any):
         """Initialize AnnDataSource from an AnnData object or file path."""
+        if adata := params.get("adata") is None:
+            raise ValueError("Parameter 'adata' must be provided as an AnnData object or path to a .h5ad file.")
+
         # Initialize internal state from params if provided (for Lumen's state management)
         self._component_registry = params.pop("_component_registry", {})
         self._materialized_tables = params.pop("_materialized_tables", [])

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -56,13 +56,6 @@ class AnnDataSource(DuckDBSource):
 
     source_type = "anndata"
 
-    _adata_store: AnnData | None = None
-    _component_registry: ComponentRegistry = {}
-    _materialized_tables: list[str] = []
-
-    _obs_ids_selected: np.ndarray | list[str] | None = None
-    _var_ids_selected: np.ndarray | list[str] | None = None
-
     def __init__(self, **params: Any):
         """Initialize AnnDataSource from an AnnData object or file path."""
         adata = params.get("adata")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,8 +1,0 @@
-"""Core tests module."""
-
-import lumen_anndata  # noqa
-
-
-def test_example():
-    """Test example."""
-    assert lumen_anndata

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,579 @@
+"""
+Tests for lumen_anndata.source.AnnDataSource
+"""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+from lumen_anndata.source import AnnDataSource
+
+
+@pytest.fixture
+def fixed_sample_anndata():
+    X = np.array([[1, 0, 3], [0, 5, 0], [2, 0, 0], [0, 1, 1]], dtype=np.float32)
+    obs_df = pd.DataFrame(
+        {
+            "cell_type": pd.Categorical(["B", "T", "B", "NK"]),
+            "n_genes": [10, 20, 5, 15],
+        },
+        index=["cell_0", "cell_1", "cell_2", "cell_3"],
+    )
+    var_df = pd.DataFrame(
+        {
+            "gene_type": pd.Categorical(["coding", "noncoding", "coding"]),
+            "highly_variable": [True, False, True],
+        },
+        index=["gene_A", "gene_B", "gene_C"],
+    )
+    adata = ad.AnnData(X, obs=obs_df, var=var_df)
+    adata.layers["counts"] = X * 2
+    adata.obsm["X_pca"] = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6], [0.7, 0.8]])
+    adata.uns["info"] = {"version": "1.0"}
+    return adata
+
+
+@pytest.fixture
+def sample_anndata():
+    """Create a sample AnnData object with various components for testing."""
+    # Create core data matrix (sparse)
+    n_obs, n_vars = 100, 50
+    data = np.random.poisson(1, size=(n_obs, n_vars)).astype(np.float32)
+    X = sp.csr_matrix(data)
+
+    # Create observation metadata
+    obs_df = pd.DataFrame(
+        {
+            "cell_type": pd.Categorical(np.random.choice(["B", "T", "NK"], size=n_obs)),
+            "n_genes_by_counts": np.random.randint(5000, 10000, size=n_obs),
+            "sample_id": np.random.choice(["sample1", "sample2", "sample3"], size=n_obs),
+        }
+    )
+
+    # Create variable metadata
+    var_df = pd.DataFrame(
+        {
+            "gene_type": pd.Categorical(np.random.choice(["protein_coding", "lncRNA", "miRNA"], size=n_vars)),
+            "highly_variable": np.random.choice([True, False], size=n_vars),
+        }
+    )
+
+    # Create AnnData object
+    adata = ad.AnnData(X, obs=obs_df, var=var_df)
+
+    # Add index names
+    adata.obs_names = [f"cell_{i}" for i in range(n_obs)]
+    adata.var_names = [f"gene_{i}" for i in range(n_vars)]
+
+    # Add layers
+    adata.layers["normalized"] = np.log1p(data)
+    adata.layers["binary"] = (data > 0).astype(np.float32)
+
+    # Add multidimensional arrays
+    adata.obsm["X_pca"] = np.random.normal(0, 1, size=(n_obs, 10))
+    adata.obsm["X_umap"] = np.random.normal(0, 1, size=(n_obs, 2))
+    adata.varm["PCs"] = np.random.normal(0, 1, size=(n_vars, 10))
+
+    # Add pairwise matrices
+    adata.obsp["distances"] = sp.csr_matrix(np.random.exponential(1, size=(n_obs, n_obs)))
+    adata.varp["correlations"] = sp.csr_matrix(np.random.normal(0, 1, size=(n_vars, n_vars)))
+
+    # Add unstructured data
+    adata.uns["clustering_params"] = {"resolution": 0.8, "method": "leiden"}
+    adata.uns["metadata"] = {"experiment_date": "2025-01-01", "operator": "Test User"}
+    adata.uns["colors"] = ["red", "blue", "green"]
+
+    return adata
+
+
+def test_initialization(sample_anndata):
+    """Test initialization of AnnDataSource with various parameters."""
+    # Test initialization with AnnData object
+    source = AnnDataSource(adata=sample_anndata)
+
+    assert source._adata_store is not None
+    assert source._adata_store is not sample_anndata  # Should be a copy
+    assert source._component_registry, "Component registry should not be empty"
+    assert "obs" in source._materialized_tables
+    assert "var" in source._materialized_tables
+    assert len(source._materialized_tables) == 2  # Initially only obs and var
+
+    # Check that obs and var tables are correctly prepared
+    obs_df_sql = source.execute("SELECT * FROM obs ORDER BY obs_id LIMIT 2")
+    pd.testing.assert_series_equal(obs_df_sql["obs_id"].astype(str).reset_index(drop=True), pd.Series(sample_anndata.obs_names[:2].astype(str)).reset_index(drop=True), check_names=False)
+    assert "cell_type" in obs_df_sql.columns
+    assert obs_df_sql["cell_type"].tolist() == sample_anndata.obs["cell_type"].iloc[:2].tolist()
+
+    var_df_sql = source.execute("SELECT * FROM var ORDER BY var_id LIMIT 2")
+    pd.testing.assert_series_equal(var_df_sql["var_id"].astype(str).reset_index(drop=True), pd.Series(sample_anndata.var_names[:2].astype(str)).reset_index(drop=True), check_names=False)
+    assert "gene_type" in var_df_sql.columns
+
+    # Test initialization parameters
+    source_with_params = AnnDataSource(adata=sample_anndata, dense_matrix_warning_threshold=500, filter_in_sql=False)
+    assert source_with_params.dense_matrix_warning_threshold == 500
+    assert source_with_params.filter_in_sql is False
+    assert source_with_params._obs_ids_selected is None  # Check initial selection state
+    assert source_with_params._var_ids_selected is None
+
+
+def test_get_tables(sample_anndata):
+    """Test the get_tables method."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    expected_tables = {
+        "obs",
+        "var",
+        "X",
+        "layer_normalized",
+        "layer_binary",
+        "obsm_X_pca",
+        "obsm_X_umap",
+        "varm_PCs",
+        "obsp_distances",
+        "varp_correlations",
+        "uns_clustering_params",
+        "uns_metadata",
+        "uns_colors",
+        "uns_keys",
+    }
+    all_tables = source.get_tables()
+    assert set(all_tables) == expected_tables
+
+    materialized_tables = source.get_tables(materialized_only=True)
+    assert set(materialized_tables) == {"obs", "var"}
+
+    # Materialize X and check again
+    source.get("X", limit=1)  # Querying X should materialize it
+    materialized_tables_after_get = source.get_tables(materialized_only=True)
+    assert set(materialized_tables_after_get) == {"obs", "var", "X"}
+
+
+def test_execute_basic_queries_fixed(fixed_sample_anndata):
+    source = AnnDataSource(adata=fixed_sample_anndata)
+    obs_result = source.execute("SELECT * FROM obs WHERE cell_type = 'B' ORDER BY obs_id")
+    expected_obs_b = fixed_sample_anndata.obs[fixed_sample_anndata.obs["cell_type"] == "B"].copy()
+    expected_obs_b["obs_id"] = expected_obs_b.index.astype(str)
+    pd.testing.assert_frame_equal(
+        obs_result.reset_index(drop=True), expected_obs_b.reset_index(drop=True).sort_values("obs_id").reset_index(drop=True), check_dtype=False, check_categorical=False
+    )
+
+    agg_result = source.execute("SELECT cell_type, SUM(n_genes) as total_genes FROM obs GROUP BY cell_type ORDER BY cell_type")
+    expected_agg = fixed_sample_anndata.obs.groupby("cell_type", observed=False)["n_genes"].sum().reset_index(name="total_genes").sort_values("cell_type")
+    pd.testing.assert_frame_equal(agg_result.reset_index(drop=True), expected_agg.reset_index(drop=True), check_dtype=False, check_categorical=False)
+
+
+def test_execute_matrix_queries_fixed(fixed_sample_anndata):
+    source = AnnDataSource(adata=fixed_sample_anndata)
+
+    x_result = source.execute("SELECT * FROM X WHERE obs_id='cell_0' AND var_id='gene_A'")
+    assert len(x_result) == 1
+    x_value = fixed_sample_anndata["cell_0", "gene_A"].X
+    if isinstance(x_value, np.ndarray):
+        assert x_result["value"].iloc[0] == pytest.approx(x_value[0, 0])
+    else:
+        assert x_result["value"].iloc[0] == pytest.approx(x_value.toarray()[0, 0])
+
+    layer_result = source.execute("SELECT * FROM layer_counts WHERE obs_id='cell_1' AND var_id='gene_B'")
+    assert len(layer_result) == 1
+    layer_value = fixed_sample_anndata["cell_1", "gene_B"].layers["counts"]
+    if isinstance(layer_value, np.ndarray):
+        assert layer_result["value"].iloc[0] == pytest.approx(layer_value[0, 0])
+    else:
+        assert layer_result["value"].iloc[0] == pytest.approx(layer_value.toarray()[0, 0])
+
+    # Ensure table 'X' is now materialized
+    assert "X" in source._materialized_tables
+    assert "layer_counts" in source._materialized_tables
+
+
+def test_get_fixed_dataframe(fixed_sample_anndata):
+    source = AnnDataSource(adata=fixed_sample_anndata)
+
+    # Get obs table with filter
+    b_cells_df = source.get("obs", cell_type="B")
+    expected_b_ids = fixed_sample_anndata.obs_names[fixed_sample_anndata.obs["cell_type"] == "B"].tolist()
+    pd.testing.assert_series_equal(
+        b_cells_df["obs_id"].sort_values().reset_index(drop=True), pd.Series(expected_b_ids).astype(str).sort_values().reset_index(drop=True), check_names=False
+    )
+    assert source._obs_ids_selected is not None
+    assert set(source._obs_ids_selected) == set(expected_b_ids)
+
+    # Get X after obs selection
+    x_df_after_obs_filter = source.get("X")
+    assert set(x_df_after_obs_filter["obs_id"].unique()) == set(expected_b_ids)
+    assert len(x_df_after_obs_filter["var_id"].unique()) == fixed_sample_anndata.n_vars
+
+    # Test with no match filter
+    no_match_df = source.get("obs", cell_type="NonExistent")
+    assert no_match_df.empty
+    assert source._obs_ids_selected is not None
+    assert len(source._obs_ids_selected) == 0
+
+
+def test_get_anndata(fixed_sample_anndata):
+    source = AnnDataSource(adata=fixed_sample_anndata)
+
+    # Filter obs to 'B' cells
+    b_cell_ids = fixed_sample_anndata.obs_names[fixed_sample_anndata.obs["cell_type"] == "B"].tolist()
+    source.get("obs", cell_type="B")
+
+    # Get AnnData for 'X' with obs filter, and var filter directly in query
+    highly_var_gene_ids = fixed_sample_anndata.var_names[fixed_sample_anndata.var["highly_variable"]].tolist()
+    filtered_adata = source.get("X", return_type="anndata", highly_variable=True)
+
+    assert isinstance(filtered_adata, ad.AnnData)
+    pd.testing.assert_index_equal(filtered_adata.obs_names.astype(str), pd.Index(b_cell_ids).astype(str))
+    assert (filtered_adata.obs["cell_type"] == "B").all()
+    pd.testing.assert_index_equal(filtered_adata.var_names.astype(str), pd.Index(highly_var_gene_ids).astype(str))
+    assert filtered_adata.var["highly_variable"].all()
+
+    if "cell_0" in filtered_adata.obs_names and "gene_A" in filtered_adata.var_names:
+        assert filtered_adata["cell_0", "gene_A"].X.item() == pytest.approx(fixed_sample_anndata["cell_0", "gene_A"].X.item())
+
+    no_obs_adata = source.get("X", return_type="anndata", cell_type="NonExistentType")
+    assert no_obs_adata.n_obs == 0
+    assert no_obs_adata.n_vars == fixed_sample_anndata.n_vars
+
+    source.reset_selection()
+    full_adata = source.get("X", return_type="anndata")
+    assert full_adata.shape == fixed_sample_anndata.shape
+    pd.testing.assert_frame_equal(full_adata.obs, fixed_sample_anndata.obs)
+    pd.testing.assert_frame_equal(full_adata.var, fixed_sample_anndata.var)
+
+
+def test_materialization_on_execute(sample_anndata):
+    source = AnnDataSource(adata=sample_anndata)
+    assert "X" not in source._materialized_tables
+    source.execute("SELECT * FROM X LIMIT 1")
+    assert "X" in source._materialized_tables
+    assert "layer_normalized" not in source._materialized_tables
+    source.execute("SELECT * FROM layer_normalized nl JOIN X x ON nl.obs_id = x.obs_id LIMIT 1")
+    assert "layer_normalized" in source._materialized_tables
+
+
+def test_get_adata_slice_labels(fixed_sample_anndata):
+    source = AnnDataSource(adata=fixed_sample_anndata)
+    original_index = pd.Index(["a", "b", "c", "d"])
+    assert source._get_adata_slice_labels(original_index, None) == slice(None)
+    assert source._get_adata_slice_labels(original_index, ["b", "d", "e"]) == ["b", "d"]
+    assert source._get_adata_slice_labels(original_index, pd.Series(["c", "a", "c"])) == ["a", "c"]
+    assert source._get_adata_slice_labels(original_index, np.array([1, 2], dtype=object)) == []
+    assert source._get_adata_slice_labels(pd.Index([10, 20, 30]), ["10", "50"]) == ["10"]
+
+
+def test_empty_adata_components():
+    """Test behavior with empty AnnData objects or components."""
+    empty_adata = ad.AnnData(np.empty((0, 0)))
+    source = AnnDataSource(adata=empty_adata)
+    tables = source.get_tables()
+    assert not tables
+
+
+def test_execute_basic_queries(sample_anndata):
+    """Test executing basic SQL queries."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Test simple SELECT query on obs table
+    obs_result = source.execute("SELECT * FROM obs LIMIT 10")
+    assert len(obs_result) == 10
+    assert "obs_id" in obs_result.columns
+    assert "cell_type" in obs_result.columns
+
+    # Test filtering with WHERE clause
+    filtered_obs = source.execute("SELECT * FROM obs WHERE cell_type = 'B'")
+    assert all(filtered_obs["cell_type"] == "B")
+
+    # Test query with aggregation
+    agg_result = source.execute("""
+        SELECT cell_type, COUNT(*) as count, AVG(n_genes_by_counts) as avg_genes
+        FROM obs
+        GROUP BY cell_type
+    """)
+    assert len(agg_result) <= 3  # Should have at most 3 cell types
+    assert "count" in agg_result.columns
+    assert "avg_genes" in agg_result.columns
+
+
+def test_execute_matrix_queries(sample_anndata):
+    """Test executing queries on matrix components."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Query the main expression matrix (X)
+    x_result = source.execute("SELECT * FROM X LIMIT 5")
+    assert "obs_id" in x_result.columns
+    assert "var_id" in x_result.columns
+    assert "value" in x_result.columns
+
+    # Query a layer
+    layer_result = source.execute("SELECT * FROM layer_normalized LIMIT 5")
+    assert "obs_id" in layer_result.columns
+    assert "var_id" in layer_result.columns
+    assert "value" in layer_result.columns
+
+    # Query a pairwise matrix (obsp)
+    obsp_result = source.execute("SELECT * FROM obsp_distances LIMIT 5")
+    assert "obs_id_1" in obsp_result.columns or "obs_id" in obsp_result.columns
+    assert "value" in obsp_result.columns
+
+
+def test_execute_multidim_queries(sample_anndata):
+    """Test executing queries on multidimensional arrays."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Query obsm component
+    pca_result = source.execute("SELECT * FROM obsm_X_pca LIMIT 5")
+    assert "obs_id" in pca_result.columns
+    assert "X_pca_0" in pca_result.columns
+
+    # Query varm component
+    varm_result = source.execute("SELECT * FROM varm_PCs LIMIT 5")
+    assert "var_id" in varm_result.columns
+    assert "PCs_0" in varm_result.columns
+
+
+def test_execute_uns_queries(sample_anndata):
+    """Test executing queries on unstructured data."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Query uns_keys
+    uns_keys = source.execute("SELECT * FROM uns_keys")
+    assert "uns_key" in uns_keys.columns
+    assert "clustering_params" in uns_keys["uns_key"].values
+    assert "metadata" in uns_keys["uns_key"].values
+
+    # Query specific uns component
+    colors = source.execute("SELECT * FROM uns_colors")
+    assert "value" in colors.columns
+    assert len(colors) == 3  # We had 3 colors
+
+
+def test_execute_with_joins(sample_anndata):
+    """Test executing queries with joins between tables."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Join obs metadata with expression data
+    join_result = source.execute("""
+        SELECT o.cell_type, COUNT(*) as expr_count
+        FROM X x
+        JOIN obs o ON x.obs_id = o.obs_id
+        WHERE x.value > 0
+        GROUP BY o.cell_type
+    """)
+
+    assert "cell_type" in join_result.columns
+    assert "expr_count" in join_result.columns
+
+    # Join var metadata with expression data
+    gene_expr = source.execute("""
+        SELECT v.gene_type, AVG(x.value) as avg_expr
+        FROM X x
+        JOIN var v ON x.var_id = v.var_id
+        GROUP BY v.gene_type
+    """)
+
+    assert "gene_type" in gene_expr.columns
+    assert "avg_expr" in gene_expr.columns
+    assert len(gene_expr) <= 3  # Should have at most 3 gene types
+
+
+def test_get_dataframe_random(sample_anndata):
+    """Test the get method returning DataFrame with random data."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Get obs table with filter
+    b_cells = source.get("obs", cell_type="B")
+    assert all(b_cells["cell_type"] == "B")
+
+    # Get with multiple filters
+    filtered = source.get("obs", cell_type="B", sample_id="sample1")
+    assert all(filtered["cell_type"] == "B")
+    assert all(filtered["sample_id"] == "sample1")
+
+    # Get with list filter
+    multi_sample = source.get("obs", sample_id=["sample1", "sample2"])
+    assert all(multi_sample["sample_id"].isin(["sample1", "sample2"]))
+
+    # Get expression data with selection tracking from previous query
+    # (This tests that the sample_id filtered obs_ids are used for X)
+    expr_data = source.get("X")
+    assert all(np.isin(expr_data["obs_id"], filtered["obs_id"]))
+
+    # Verify internal state tracking
+    assert source._obs_ids_selected is not None
+    assert len(source._obs_ids_selected) == len(filtered)
+
+
+def test_get_anndata(sample_anndata):
+    """Test the get method returning AnnData."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # First filter the obs table to establish a selection
+    source.get("obs", cell_type="T")
+
+    # Get filtered AnnData
+    filtered_adata = source.get("X", return_type="anndata")
+
+    # Check if filtering was applied correctly
+    assert isinstance(filtered_adata, ad.AnnData)
+    assert np.all(filtered_adata.obs["cell_type"] == "T")
+    assert filtered_adata.n_obs < sample_anndata.n_obs
+    assert filtered_adata.n_vars == sample_anndata.n_vars  # Vars not filtered
+
+    # Test filtering both obs and vars
+    source.get("var", highly_variable=True)  # Establish var selection
+    filtered_adata_2 = source.get("X", return_type="anndata")
+
+    # Check if both filters were applied
+    assert np.all(filtered_adata_2.obs["cell_type"] == "T")
+    # All variables in the result should be highly variable
+    assert filtered_adata_2.var["highly_variable"].all()
+    assert filtered_adata_2.n_obs < sample_anndata.n_obs
+    assert filtered_adata_2.n_vars < sample_anndata.n_vars
+
+    # Reset selection and check
+    source.reset_selection()
+    unfiltered = source.get("X", return_type="anndata")
+    assert unfiltered.n_obs == sample_anndata.n_obs
+    assert unfiltered.n_vars == sample_anndata.n_vars
+
+
+def test_reset_selection(sample_anndata):
+    """Test the reset_selection method with direct ID filtering."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # 1. Test resetting obs selection
+    # First get a subset of cell IDs
+    cells = source.execute("SELECT obs_id FROM obs LIMIT 10")
+    test_cell_ids = cells["obs_id"].tolist()
+
+    # Apply direct ID filtering
+    filtered_obs = source.get("obs", obs_id=test_cell_ids)
+    assert len(filtered_obs) == len(test_cell_ids)
+
+    # Verify selection is active by checking internal state
+    assert source._obs_ids_selected is not None
+    assert set(source._obs_ids_selected) == set(test_cell_ids)
+
+    # Verify filtered X data only contains the selected obs_ids
+    x_filtered = source.get("X")
+    assert set(x_filtered["obs_id"].unique()) == set(test_cell_ids)
+
+    # Reset obs selection only
+    source.reset_selection(dim="obs")
+
+    # Verify internal state is reset
+    assert source._obs_ids_selected is None
+
+    # Verify data is no longer filtered by obs
+    x_after_reset = source.get("X")
+    assert len(set(x_after_reset["obs_id"].unique())) == sample_anndata.n_obs
+
+    # 2. Test resetting var selection
+    # First get a subset of gene IDs
+    genes = source.execute("SELECT var_id FROM var LIMIT 5")
+    test_gene_ids = genes["var_id"].tolist()
+
+    # Apply direct ID filtering
+    filtered_var = source.get("var", var_id=test_gene_ids)
+    assert len(filtered_var) == len(test_gene_ids)
+
+    # Verify selection is active
+    assert source._var_ids_selected is not None
+    assert set(source._var_ids_selected) == set(test_gene_ids)
+
+    # Verify filtered X data only contains the selected var_ids
+    x_filtered = source.get("X")
+    assert set(x_filtered["var_id"].unique()) == set(test_gene_ids)
+
+    # Reset var selection
+    source.reset_selection(dim="var")
+
+    # Verify internal state is reset
+    assert source._var_ids_selected is None
+
+    # Verify data is no longer filtered by var
+    x_after_reset = source.get("X")
+    assert len(set(x_after_reset["var_id"].unique())) == sample_anndata.n_vars
+
+    # 3. Test resetting both dimensions at once
+    # Apply filtering on both dimensions
+    source.get("obs", obs_id=test_cell_ids)
+    source.get("var", var_id=test_gene_ids)
+
+    # Verify both selections are active
+    assert source._obs_ids_selected is not None
+    assert source._var_ids_selected is not None
+
+    # Verify filtered X contains only selected IDs from both dimensions
+    x_filtered = source.get("X")
+    assert set(x_filtered["obs_id"].unique()) == set(test_cell_ids)
+    assert set(x_filtered["var_id"].unique()) == set(test_gene_ids)
+
+    # Reset both dimensions
+    source.reset_selection()
+
+    # Verify both internal states are reset
+    assert source._obs_ids_selected is None
+    assert source._var_ids_selected is None
+
+    # Verify data is completely unfiltered
+    x_fully_reset = source.get("X")
+    assert len(x_fully_reset["obs_id"].unique()) == sample_anndata.n_obs
+    assert len(x_fully_reset["var_id"].unique()) == sample_anndata.n_vars
+
+    # Verify that querying obs or var now returns all items
+    all_obs = source.get("obs")
+    assert len(all_obs) == sample_anndata.n_obs
+    assert source._obs_ids_selected is not None  # get("obs") will re-select all if no filter
+    assert len(source._obs_ids_selected) == sample_anndata.n_obs
+
+    all_var = source.get("var")
+    assert len(all_var) == sample_anndata.n_vars
+    assert source._var_ids_selected is not None
+    assert len(source._var_ids_selected) == sample_anndata.n_vars
+
+
+def test_chained_filtering(sample_anndata):
+    """Test the effect of chained filtering operations."""
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Select T cells
+    t_cells = source.get("obs", cell_type="T")
+    t_cell_count = len(t_cells)
+
+    # Further filter to sample1
+    t_cells_sample1 = source.get("obs", sample_id="sample1")
+    assert len(t_cells_sample1) < t_cell_count  # Should be fewer rows
+
+    # Should now have both filters applied
+    expr_data = source.get("X")
+
+    # Verify through direct SQL to check
+    verification = source.execute("""
+        SELECT COUNT(*) as count FROM X x
+        JOIN obs o ON x.obs_id = o.obs_id
+        WHERE o.cell_type = 'T' AND o.sample_id = 'sample1'
+    """)
+
+    assert len(expr_data) == verification["count"].iloc[0]
+
+
+def test_get_with_sql_transforms(sample_anndata):
+    """Test the get method with SQL transforms."""
+    from lumen.transforms import SQLFilter
+
+    source = AnnDataSource(adata=sample_anndata)
+
+    # Define a SQL transform to add a WHERE clause
+    sql_filter = SQLFilter(conditions=[("cell_type", "B")])
+
+    # Get data with the transform
+    filtered = source.get("obs", sql_transforms=[sql_filter])
+    assert all(filtered["cell_type"] == "B")
+
+    # Combine with direct filtering
+    combined = source.get("obs", sample_id="sample1", sql_transforms=[sql_filter])
+    assert all(combined["cell_type"] == "B")
+    assert all(combined["sample_id"] == "sample1")


### PR DESCRIPTION
Builds on top of https://github.com/holoviz-topics/lumen-anndata/pull/9

> I think the Lumen should be somewhat aware of anndata file content beyond just the obs and var dataframes, e.g. it should know where umap results are typically stored (.obsm["X_umap"]).

Makes all of Anndata's components available to Lumen.

1. Introduces a `_component_registry` for all AnnData parts (`X`, `layers`, `obsm`, `obsp`, etc.). These components are now lazily materialized into SQL tables only when explicitly queried as a DataFrame or needed by a custom SQL `execute()` call.

2. The internal `_obs_ids_selected` and `_var_ids_selected` are now updated only when `get()` is called on the "obs" or "var" tables for a DataFrame, providing clearer selection propagation. Added `reset_selection()` method to clear them.

This means, it's now possible to do:
```python
source.get("obsm_X_pca")
```

Or
```python
source.execute("SELECT * FROM X WHERE value > 3")  # and maybe a join
```

More significantly, the LLM can generate these SQL queries by itself, and with https://github.com/holoviz/lumen/pull/1233 we can natively support plotting these variables, and we don't have to resort to creating tool wrappers for each and individual scanpy plotting function.

Example output:
`source.get_tables()` 
```python
['X',
 'obs',
 'obsm_X_pca',
 'obsm_X_tsne',
 'obsm_X_umap',
 'obsp_connectivities',
 'obsp_distances',
 'uns_Phenograph_cluster_colors',
 'uns_citation',
 'uns_default_embedding',
 'uns_dendrogram_Phenograph_cluster',
 'uns_keys',
 'uns_neighbors',
 'uns_pca',
 'uns_sample_name_colors',
 'uns_schema_reference',
 'uns_schema_version',
 'uns_title',
 'uns_umap',
 'var',
 'varm_PCs']
```

<img width="585" alt="image" src="https://github.com/user-attachments/assets/184f2909-b81f-49df-922a-27295f77f296" />
