### PR TITLE
Yield back control

### DIFF
--- a/src/lumen_anndata/controls.py
+++ b/src/lumen_anndata/controls.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from io import BytesIO
 
 import cellxgene_census
@@ -125,6 +127,7 @@ class CellXGeneSourceControls(SourceControls):
         Uploads an h5ad file and returns an AnnDataSource.
         """
         with self._tabulator.param.update(loading=True), self.param.update(disabled=True):
+            await asyncio.sleep(0.05)  # yield the event loop to ensure UI updates
             dataset_id = self.datasets_df.loc[event.row, "dataset_id"]
             locator = cellxgene_census.get_source_h5ad_uri(dataset_id, census_version=self.census_version)
             # Initialize s3fs


### PR DESCRIPTION
Turns out the asyncio.sleep was there for a reason, to give the UI some time to respond. Or else, the loading indicator will NOT show and it makes it seem like it doesn't work.