### PR TITLE
Improve cellxgene source controls

### DIFF
--- a/src/lumen_anndata/controls.py
+++ b/src/lumen_anndata/controls.py
@@ -146,12 +146,16 @@ class CellXGeneSourceControls(SourceControls):
             self.param.trigger("trigger_add")  # automatically trigger the add
 
     def __panel__(self):
-        original_controls = super().__panel__()
-        return pn.Column(
+        czi_controls = pn.Column(
             pn.pane.Markdown(
-                object="## CELLxGENE Census Source Input\n*Click on download icons to ingest datasets.",
+                object="*Click on download icons to ingest datasets.*",
                 margin=0,
             ),
             self._tabulator,
-            original_controls,
+        )
+        original_controls = super().__panel__()
+        return pn.Tabs(
+            ("Upload Datasets", original_controls),
+            ("CELLxGENE Census Datasets", czi_controls),
+            dynamic=True,
         )


### PR DESCRIPTION
1. move it to onload so it doesn't block initialization
2. move the original source controls below
3. add a title
4. automatically trigger "use file(s)" so users doesn't have to click twice
<img width="1017" height="881" alt="image" src="https://github.com/user-attachments/assets/b29f3eb7-75ea-4cf4-b8dd-1fb34bddb921" />
