### PR TITLE
Fix cellxgene requirement test

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["pyviz/label/dev", "conda-forge", "bioconda"]
 platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
 
 [tasks]
-install-git-deps = 'pip install "lumen[ai] @ git+https://github.com/holoviz/lumen.git@main" "hv-anndata @ git+https://github.com/holoviz-topics/hv-anndata.git@main" "cellxgene_census"'
+install-git-deps = 'pip install "lumen[ai] @ git+https://github.com/holoviz/lumen.git@main" "hv-anndata @ git+https://github.com/holoviz-topics/hv-anndata.git@main"'
 install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
 postinstall = 'pixi run install-git-deps'
 


### PR DESCRIPTION
We can remove the cellxgene requirement from pixi, but users can still use the requirements in pyproject