### PR TITLE
Fix cursor changes

### DIFF
--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -143,11 +143,12 @@ class AnnDataSource(DuckDBSource):
         tables : dict[str, pd.DataFrame]
             Dictionary mapping table names to DataFrames to register.
         """
-        for table_name, df in tables.items():  # noqa: B007 iused implicitly with duckdb
+        for table_name, df in tables.items():
             try:
-                self.connection.sql(f"CREATE TABLE {table_name} AS SELECT * FROM df")
-            except Exception:
-                continue
+                self.connection.from_df(df).to_view(table_name, replace=True)
+            except Exception as e:
+                self.param.warning(f"Failed to register table '{table_name}' with DuckDB: {e}")
+
             if table_name not in self._materialized_tables:
                 self._materialized_tables.append(table_name)
             if table_name not in self.tables:

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -344,7 +344,7 @@ class AnnDataSource(DuckDBSource):
             except Exception as e:
                 # Create empty table
                 with self.connection.cursor() as cursor:
-                    cursor.execute(f"CREATE TABLE {table_name} AS SELECT * FROM (SELECT 1 AS dummy) WHERE 0")
+                    cursor.execute(f"CREATE VIEW {table_name} AS SELECT * FROM (SELECT 1 AS dummy) WHERE 0")
                 self.param.warning(f"Failed to register table '{table_name}' with DuckDB: {e}")
                 # Still mark as materialized even if it failed
                 if table_name not in self._materialized_tables:


### PR DESCRIPTION
In https://github.com/holoviz/lumen/pull/1410 we changed to using cursor instead of connection to fix a thread-safety issue, but this caused an issue with lumen-anndata; specifically, cursors cannot see connections' views

<img width="1736" height="1500" alt="image" src="https://github.com/user-attachments/assets/91178d42-56f3-4cb6-9b9c-21d579e11aec" />

To work around that, I create table instead:
https://duckdb.org/docs/stable/guides/python/import_pandas.html


I tried various other ways:

TEMP TABLE: fails
```python
import duckdb
import pandas as pd

conn = duckdb.connect()
df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})

# Create a temporary table instead of registering
conn.execute("CREATE TEMP TABLE test_table AS SELECT * FROM df")

# New cursor
cursor = conn.cursor()
try:
    result = cursor.execute("SELECT * FROM test_table").fetchall()
    print("SUCCESS:", result)
except Exception as e:
    print(f"ERROR: {e}")
finally:
    cursor.close()
```

Create table manually; works but annoying to build the schema
```python
import duckdb
import pandas as pd

conn = duckdb.connect()
df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})

# Insert data into a real table
conn.execute("""
    CREATE TABLE test_table (
        x INTEGER,
        y INTEGER
    )
""")

# Insert the dataframe data
conn.execute("INSERT INTO test_table SELECT * FROM df")

# New cursor
cursor = conn.cursor()
try:
    result = cursor.execute("SELECT * FROM test_table").fetchall()
    print("SUCCESS:", result)
except Exception as e:
    print(f"ERROR: {e}")
finally:
    cursor.close()
```

Create with pandas; works partially and warning about use sqlalchemy instead of duckdb conn:
```python
import duckdb
import pandas.io.sql as pdsql
import pandas as pd

conn = duckdb.connect()
df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})

# Use pandas to_sql method
df.to_sql('test_table', conn, if_exists='replace', index=False)

# New cursor
cursor = conn.cursor()
try:
    result = cursor.execute("SELECT * FROM test_table").fetchall()
    print("SUCCESS:", result)
except Exception as e:
    print(f"ERROR: {e}")
finally:
    cursor.close()
```