### PR TITLE
Fix ManifoldMap linked selection

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -21,6 +21,9 @@ lint = ["py312", "lint"]
 [dependencies]
 anndata = ">=0.11.4"
 bokeh = "*"
+# requests (pulled in transitively) only supports chardet <6; pin it so pip
+# installing lumen's deps can't upgrade to an incompatible chardet 7.x.
+chardet = "<6"
 holoviews = ">=1.17.0"
 hvplot = "*"
 jinja2 = ">3.0"

--- a/src/lumen_anndata/analysis.py
+++ b/src/lumen_anndata/analysis.py
@@ -6,6 +6,7 @@ from holoviews import Dataset, renderer
 from hv_anndata import register
 from lumen.ai.analysis import Analysis
 from lumen.ai.utils import describe_data
+from lumen.transforms import SQLFilter
 from panel.layout import Column
 from panel.pane.markup import Markdown
 from panel_material_ui import Button
@@ -21,7 +22,6 @@ from .views import (
 renderer("bokeh").webgl = False
 register()
 
-#: Name of the table materialized from a manifold-map linked selection.
 SELECTION_TABLE = "obs_linked_selection"
 
 
@@ -57,26 +57,22 @@ class ManifoldMapVisualization(AnnDataAnalysis):
         instance._chat_message = None
         instance._reset_col = None
         instance._selection_markdown = None
-        instance._context = None
         instance._pipeline = None
         return instance
 
     def __call__(self, pipeline, context):
-        # Hold references to the lumen context and the original (unfiltered)
-        # pipeline so the selection callbacks (which fire after __call__
-        # returns) can read/write shared state and restore on reset.
-        self._context = context
         self._pipeline = pipeline
         self._mm = ManifoldMapPanel(pipeline=pipeline)
         self._mm.param.watch(partial(self._sync_selection, pipeline), 'selection_expr')
         return self._mm
 
     def _reset_selection(self, event):
-        # Restore the original, unfiltered pipeline/source and clear the plot.
-        context = self._context
-        context['source'] = self._pipeline.source
-        context['pipeline'] = self._pipeline
-        context['table'] = self._pipeline.table
+        # Republish the original pipeline so downstream reverts to it.
+        self._dynamic_provides = {
+            'source': self._pipeline.source,
+            'pipeline': self._pipeline,
+            'table': self._pipeline.table,
+        }
         self._mm.selection_expr = None
         self._mm._ls.selection_expr = None
         self._initialized_selection = False
@@ -87,37 +83,41 @@ class ManifoldMapVisualization(AnnDataAnalysis):
         if event.new is None:
             return
 
-        context = self._context
-
-        # Map the selection expression to the selected observation IDs, using
-        # the dimensions the plot is currently displaying so the expression
-        # resolves against the Dataset.
-        adata = pipeline.source.get('obs', return_type='anndata')
+        # Apply the lasso to the data the map is currently showing (its own
+        # adata), so selecting on an already-filtered map narrows that subset
+        # instead of re-selecting against the full obs table. obs_id is the obs
+        # index promoted to a column, so obs_names gives the selected ids.
+        adata = self._mm.adata
         ds = Dataset(adata, self._mm._manifold_map.current_kdims())
         mask = event.new.apply(ds)
-        selected = pipeline.data[mask]
-        obs_ids = list(selected.obs_id)
+        obs_ids = [str(obs_id) for obs_id in adata.obs_names[mask]]
 
-        # Materialize the selection as its own queryable table so downstream
-        # actors (SQLAgent, VegaLite, table views) can target it directly
-        # instead of relying on filter state that raw SQL bypasses.
-        if obs_ids:
-            id_list = ", ".join(
-                "'" + str(obs_id).replace("'", "''") + "'" for obs_id in obs_ids
-            )
-            where = f' WHERE "obs_id" IN ({id_list})'
-        else:
-            where = " WHERE FALSE"
+        # Materialize the selection keyed by obs_id off base obs; obs_id is a
+        # global identity, so filtering base obs by the ids selected on the
+        # current view yields the narrowed subset regardless of current table.
+        # SQLFilter handles quoting/dialect (as AnnDataSource does for obs_id);
+        # an empty list is a no-op there, so guard it with an empty result.
+        base_sql = 'SELECT * FROM "obs"'
         tables = dict(pipeline.source.tables)
-        tables[SELECTION_TABLE] = f'SELECT * FROM "obs"{where}'
+        if obs_ids:
+            tables[SELECTION_TABLE] = SQLFilter(
+                conditions=[("obs_id", obs_ids)]
+            ).apply(base_sql)
+        else:
+            tables[SELECTION_TABLE] = f'SELECT * FROM ({base_sql}) WHERE FALSE'
         source = pipeline.source.create_sql_expr_source(tables)
 
-        context['source'] = source
-        context['pipeline'] = pipeline.clone(
-            source=source, table=SELECTION_TABLE, schema=None
-        )
-        context['table'] = SELECTION_TABLE
-        context['data'] = await describe_data(selected)
+        # Publish through the analysis out-context (Analysis._dynamic_provides);
+        # the input context is a snapshot, so mutating it wouldn't propagate.
+        # `source` is included so it registers for downstream discovery.
+        self._dynamic_provides = {
+            'source': source,
+            'pipeline': pipeline.clone(
+                source=source, table=SELECTION_TABLE, schema=None
+            ),
+            'table': SELECTION_TABLE,
+            'data': await describe_data(source.get(SELECTION_TABLE)),
+        }
 
         if not self._initialized_selection:
             button = Button(

--- a/src/lumen_anndata/analysis.py
+++ b/src/lumen_anndata/analysis.py
@@ -2,12 +2,10 @@ from functools import partial
 
 import param
 
-from anndata.acc import A
 from holoviews import Dataset, renderer
 from hv_anndata import register
 from lumen.ai.analysis import Analysis
 from lumen.ai.utils import describe_data
-from lumen.filters import ConstantFilter
 from panel.layout import Column
 from panel.pane.markup import Markdown
 from panel_material_ui import Button
@@ -22,6 +20,9 @@ from .views import (
 
 renderer("bokeh").webgl = False
 register()
+
+#: Name of the table materialized from a manifold-map linked selection.
+SELECTION_TABLE = "obs_linked_selection"
 
 
 class AnnDataAnalysis(Analysis):
@@ -54,32 +55,71 @@ class ManifoldMapVisualization(AnnDataAnalysis):
         instance = super().instance(**params)
         instance._initialized_selection = False
         instance._chat_message = None
-        instance._filt = None
         instance._reset_col = None
+        instance._selection_markdown = None
+        instance._context = None
+        instance._pipeline = None
         return instance
 
     def __call__(self, pipeline, context):
+        # Hold references to the lumen context and the original (unfiltered)
+        # pipeline so the selection callbacks (which fire after __call__
+        # returns) can read/write shared state and restore on reset.
+        self._context = context
+        self._pipeline = pipeline
         self._mm = ManifoldMapPanel(pipeline=pipeline)
         self._mm.param.watch(partial(self._sync_selection, pipeline), 'selection_expr')
         return self._mm
 
     def _reset_selection(self, event):
-        source = self._memory['source']
-        source._obs_ids_selected = None
+        # Restore the original, unfiltered pipeline/source and clear the plot.
+        context = self._context
+        context['source'] = self._pipeline.source
+        context['pipeline'] = self._pipeline
+        context['table'] = self._pipeline.table
         self._mm.selection_expr = None
         self._mm._ls.selection_expr = None
         self._initialized_selection = False
+        if self._selection_markdown is not None:
+            self._selection_markdown.object = "Selection cleared."
 
     async def _sync_selection(self, pipeline, event):
         if event.new is None:
             return
 
+        context = self._context
+
+        # Map the selection expression to the selected observation IDs, using
+        # the dimensions the plot is currently displaying so the expression
+        # resolves against the Dataset.
+        adata = pipeline.source.get('obs', return_type='anndata')
+        ds = Dataset(adata, self._mm._manifold_map.current_kdims())
+        mask = event.new.apply(ds)
+        selected = pipeline.data[mask]
+        obs_ids = list(selected.obs_id)
+
+        # Materialize the selection as its own queryable table so downstream
+        # actors (SQLAgent, VegaLite, table views) can target it directly
+        # instead of relying on filter state that raw SQL bypasses.
+        if obs_ids:
+            id_list = ", ".join(
+                "'" + str(obs_id).replace("'", "''") + "'" for obs_id in obs_ids
+            )
+            where = f' WHERE "obs_id" IN ({id_list})'
+        else:
+            where = " WHERE FALSE"
+        tables = dict(pipeline.source.tables)
+        tables[SELECTION_TABLE] = f'SELECT * FROM "obs"{where}'
+        source = pipeline.source.create_sql_expr_source(tables)
+
+        context['source'] = source
+        context['pipeline'] = pipeline.clone(
+            source=source, table=SELECTION_TABLE, schema=None
+        )
+        context['table'] = SELECTION_TABLE
+        context['data'] = await describe_data(selected)
+
         if not self._initialized_selection:
-            source = pipeline.source.create_sql_expr_source(pipeline.source.tables)
-            self._memory['source'] = source
-            self._memory['pipeline'] = selected = pipeline.clone(source=source)
-            self._filt = ConstantFilter(field='obs_id')
-            selected.add_filter(self._filt)
             button = Button(
                 label="Reset Selection",
                 on_click=self._reset_selection
@@ -87,20 +127,10 @@ class ManifoldMapVisualization(AnnDataAnalysis):
             self._selection_markdown = Markdown()
             self._reset_col = Column(self._selection_markdown, button)
             self._initialized_selection = True
-        else:
-            source = self._memory['source']
-
-        adata = pipeline.source.get('obs', return_type='anndata')
-        dr_options = list(adata.obsm.keys())
-        var = dr_options[0]
-        ds = Dataset(adata, [A.obsm[var][:, 0], A.obsm[var][:, 1]])
-        mask = event.new.apply(ds)
-        source._obs_ids_selected = self._filt.value = list(pipeline.data[mask].obs_id)
         self._selection_markdown.object = (
-            f"Selected {len(source._obs_ids_selected)} points, "
+            f"Selected {len(obs_ids)} points into table `{SELECTION_TABLE}`, "
             "which will be used for subsequent calls."
         )
-        self._memory["data"] = await describe_data(pipeline.data[mask])
         self._chat_message = self.interface.stream(self._reset_col, user="Assistant", message=self._chat_message)
 
 

--- a/src/lumen_anndata/source.py
+++ b/src/lumen_anndata/source.py
@@ -233,10 +233,9 @@ class AnnDataSource(DuckDBSource):
 
         original_str_index = original_adata_index.astype(str)
 
-        if isinstance(selected_ids, (pd.Series, np.ndarray)):
-            unique_selected_ids = pd.Index(selected_ids).unique().astype(str)
-        elif isinstance(selected_ids, list):
-            unique_selected_ids = pd.Index(list(set(selected_ids))).astype(str)
+        # pd.Index accepts Series, ndarray, list, Index and pandas extension
+        # arrays (e.g. ArrowStringArray), so a single path handles every case.
+        unique_selected_ids = pd.Index(selected_ids).unique().astype(str)
 
         present_ids = original_str_index.intersection(unique_selected_ids)
         return sorted(present_ids.to_list())

--- a/src/lumen_anndata/views.py
+++ b/src/lumen_anndata/views.py
@@ -53,9 +53,11 @@ class ManifoldMapPanel(AnnDataPanel):
 
     view_type = "manifold_map"
 
-    # Holds the rendered ManifoldMap so selection callbacks can read the
-    # dimensions (reduction/axes) currently on display.
-    _manifold_map = None
+    def __init__(self, **params):
+        super().__init__(**params)
+        # Set in _render_visualization; lets selection callbacks read the
+        # dimensions (reduction/axes) currently on display.
+        self._manifold_map = None
 
     def _render_visualization(self):
         if self._ls is None:

--- a/src/lumen_anndata/views.py
+++ b/src/lumen_anndata/views.py
@@ -55,9 +55,7 @@ class ManifoldMapPanel(AnnDataPanel):
 
     def __init__(self, **params):
         super().__init__(**params)
-        # Set in _render_visualization; lets selection callbacks read the
-        # dimensions (reduction/axes) currently on display.
-        self._manifold_map = None
+        self._manifold_map = None  # set on render; read by selection callbacks
 
     def _render_visualization(self):
         if self._ls is None:

--- a/src/lumen_anndata/views.py
+++ b/src/lumen_anndata/views.py
@@ -53,10 +53,15 @@ class ManifoldMapPanel(AnnDataPanel):
 
     view_type = "manifold_map"
 
+    # Holds the rendered ManifoldMap so selection callbacks can read the
+    # dimensions (reduction/axes) currently on display.
+    _manifold_map = None
+
     def _render_visualization(self):
         if self._ls is None:
             self._init_link_selections()
-        return ManifoldMap(adata=self.adata, ls=self._ls)
+        self._manifold_map = ManifoldMap(adata=self.adata, ls=self._ls)
+        return self._manifold_map
 
 
 class RankGenesGroupsTracksplotPanel(AnnDataPanel):


### PR DESCRIPTION
Upon doing a linked selection, it now creates a table that can be selected.

https://github.com/user-attachments/assets/016c1e22-7678-42db-8dd1-039d595d788c

Ports the selection off the removed `self._memory` onto lumen's `context`, and
replaces the `ConstantFilter` with a materialized `obs_linked_selection` table.

Replaced ConstantFilter because it kept the selection as pipeline filter state that only `AnnDataSource.get()` uses. The SQLAgent runs raw SQL through `execute()`, which bypasses that filter, so queries returned the full table, not the selection. Baking the selection into a table (`WHERE obs_id IN (...)`) makes it survive downstream path (SQL, Vega, joins) and
is discoverable by name.

Also builds the selection `Dataset` from `ManifoldMap.current_kdims()` so it matches the reduction/axes on display (needs the [hv-anndata `current_kdims()` PR](https://github.com/holoviz-topics/hv-anndata/pull/162)).